### PR TITLE
feat: add transparency to overlay window

### DIFF
--- a/D2Stats.au3
+++ b/D2Stats.au3
@@ -2199,7 +2199,7 @@ Func CreateOverlayWindow()
                                 $aPos[3] - _GUI_Option("overlay-y"), _
                                 $aPos[0] + _GUI_Option("overlay-x"), _
                                 $aPos[1] + _GUI_Option("overlay-y"), _
-                                $WS_POPUP, BitOR($WS_EX_LAYERED, $WS_EX_TOPMOST, $WS_EX_TOOLWINDOW))
+                                $WS_POPUP, BitOR($WS_EX_LAYERED, $WS_EX_TOPMOST, $WS_EX_TOOLWINDOW, $WS_EX_TRANSPARENT))
     
     If @error Or $g_hOverlayGUI = 0 Then
         $g_hOverlayGUI = 0


### PR DESCRIPTION
Fix: Prevent D2Stat overlay from stealing focus during combat

The D2Stat notification overlay, when clicked, would steal focus away from the main game window, causing significant inconvenience, especially when users are engaged in time-sensitive actions like combat.

This fix resolves the issue by ensuring mouse input passes through the overlay directly to the game below.

Technical implementation:
Added the WS_EX_TRANSPARENT extended window style to the D2Stat overlay window. This flag instructs the system to ignore the window for mouse hits, allowing clicks to register on the underlying game window.